### PR TITLE
default image url not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,14 +16,13 @@ XBMC.prototype.config = function (obj) {
 };
 
 XBMC.prototype.notify = function (msg,title,image,callback) {
-  
+
   if (!callback) callback = function () {};
   var params = {
     title : title || this._config.title,
-    message   : msg || this._config.message
+    message   : msg || this._config.message,
+    image   : image || this._config.image
   };
-  
-  if (image) params.image = image;
 
   var json = { jsonrpc: "2.0", method: "GUI.ShowNotification", params: params, id: 1 };
   var uri = "http://" + this._config.host + '/jsonrpc';

--- a/test/test.js
+++ b/test/test.js
@@ -5,19 +5,17 @@ var mocha  = require('mocha'),
     xbmc   = require('../index.js'),
     sinon  = require('sinon');
 
-sinon.stub(xbmc,'post', function (uri,json,callback) {
-  callback(undefined,{statusCode: 200});
-});
-
 
 describe('XBMC Notify', function () {
 
-  it('Config returns expected defaults', function () {
+  it('Config returns expected defaults', function (done) {
     var config = xbmc.config();
     expect(config).to.have.deep.property('host','127.0.0.1:8080');
+    expect(config).to.have.deep.property('title','xbmc-notify');
     expect(config.user).to.not.be.ok;
     expect(config.pass).to.not.be.ok;
     expect(config.image).to.not.be.ok;
+    done();
   });
 
   it('Config accepts new parameters', function (done) {
@@ -25,24 +23,59 @@ describe('XBMC Notify', function () {
       host  : '1.2.3.4:9090',
       user  : 'testuser',
       pass  : 'testpass',
-      image : 'testimage'
+      image : 'testimage',
+      title : 'testTitle'
     });
 
     expect(config).to.have.deep.property('host','1.2.3.4:9090');
     expect(config).to.have.deep.property('user','testuser');
     expect(config).to.have.deep.property('pass','testpass');
     expect(config).to.have.deep.property('image','testimage');
+    expect(config).to.have.deep.property('title','testTitle');
 
     done();
   });
 
+
+  it('Send notification with defaults', function (done){
+    var msg = 'this is a msg';
+
+    buildStub(msg, 'testimage', 'testTitle');
+
+    xbmc.notify(msg);
+    done();
+  });
+
   it('Send notification', function (done){
-    xbmc.notify('this is a msg','Title','http://path/to/image',function(err,res){
+    var msg = 'this is a msg',
+        title = 'Title',
+        image = 'http://path/to/image';
+
+    buildStub(msg, image, title);
+
+    xbmc.notify(msg, title, image,function(err,res){
       expect(err).to.not.be.ok;
       expect(res).to.have.deep.property('statusCode',200);
       done();
     });
-    
+
   });
 
 });
+
+function buildStub(msg, image, title){
+  //clear out previous stub if it exists
+  if (xbmc.post.restore){
+    xbmc.post.restore();
+  }
+
+  sinon.stub(xbmc,'post', function (uri,json,callback) {
+    expect(json.params).to.have.property('image', image);
+    expect(json.params).to.have.property('title', title);
+    expect(json.params).to.have.property('message', msg);
+    if (callback){
+      callback(undefined,{statusCode: 200});
+    }
+  });
+
+}


### PR DESCRIPTION
Updated the test to show an example where the default image wasn't getting posted on a notify. This issue was fixed by adding image to the params block around line 24.

Added the title into the "Config returns expected defaults" test

Added image and title to the 'Config accepts new parameters' test
